### PR TITLE
Add cache directory to prevent IOExceptions

### DIFF
--- a/benchmark/cache/.gitignore
+++ b/benchmark/cache/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore


### PR DESCRIPTION
Without an existing cache directory, WikipediaApiInterface.flush() throws an IOException while calling .createNewFile().
I added a .gitignore file as described in http://stackoverflow.com/a/932982/1501100 to create an empty directory while ignoring its content.
