### PR TITLE
Update Annotation.java

### DIFF
--- a/src/it/acubelab/batframework/data/Annotation.java
+++ b/src/it/acubelab/batframework/data/Annotation.java
@@ -42,7 +42,7 @@ public class Annotation extends Tag implements Serializable, Cloneable{
 	}
 
 	@Override public int hashCode() {
-		return (""+this.getConcept()+m.hashCode()).hashCode();
+		return (this.getConcept()^m.hashCode());
 	}
 	
 	public static <E extends Tag> void prefetchRedirectList(List<HashSet<E>> annotations, WikipediaApiInterface api) throws IOException{


### PR DESCRIPTION
Inappropriate design of the Hash Function :-

Two totally different Annotations can easily map to the same hash value, which in my opinion was not intentional here.

For example :-

Annotation 1: [Concept: 13, Position: 2, Length: 1] maps to ("" + "13" + "2^1").hascode() i.e. "132".hashcode()
Annotation 2: [Concept: 1, Position: 2, Length: 5] maps to ("" + "1" + "2^5").hascode() i.e. "132".hashcode()

This was just one such example; one can easily construct similar examples.

Instead, my proposed Hash Function should take care of such cases.

Thanks.